### PR TITLE
[Wiki] Apply styling to 

### DIFF
--- a/src/components/markdown/MarkdownView.vue
+++ b/src/components/markdown/MarkdownView.vue
@@ -76,11 +76,14 @@ function MoveToHash() {
 
     ul,
     ol {
-        @apply list-inside list-disc mt-2;
+       @apply list-inside list-disc mt-2;
 
         li {
-            @apply text-sm;
+            @apply text-sm mt-1;
         }
+	ul,ol {
+	    @apply ml-4 mt-1;
+	}
     }
 
     pre {


### PR DESCRIPTION
Applies a simple margin left to all nested ul / li's.
Also adds a little margin at the top of all li's for breathability and readability.

Purifying Criteria
![image](https://github.com/user-attachments/assets/931e54a0-50ab-40c2-8514-32ba6f509e98)

Upcoming `.fsb` file format page
![image](https://github.com/user-attachments/assets/e8f4067c-a9c0-4760-baf6-ad4001235506)
